### PR TITLE
Fix dirty state

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ before:
   hooks:
     # you may remove this if you don't use vgo
     - go mod download
+    # Note: for check
+    - git diff
 
 builds:
 - env:
@@ -21,6 +23,9 @@ builds:
   ignore:
     - goos: darwin
       goarch: 386
+  hooks:
+    # Note: for check
+    post: git diff
 
 archive:
   # replacements:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,8 @@
 before:
   hooks:
     # you may remove this if you don't use vgo
-    - go mod download
+    # Note: comment out because executed by travis ci "install" task
+    # - go mod download
     # Note: for check
     - git diff
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,11 +58,3 @@ brew:
   description: 'Utility tool of concatnating and printing file to various services'
   test: |
     system '#{bin}/gat -v'
-
-nfpm:
-  license: MIT
-  maintainer: Fuminori Sakamoto
-  homepage: https://github.com/goldeneggg/gat
-  formats:
-    - deb
-    - rpm

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-#GO ?= go
-#GODEP ?= godep
-#GOLINT ?= golint
 NAME := gat
 SRCS := $(shell find . -type f -name '*.go' | \grep -v 'vendor')
 PGM_PATH := 'github.com/goldeneggg/gat'

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // VERSION info
-const VERSION = "0.8.1"
+const VERSION = "0.8.2"


### PR DESCRIPTION
I'd like to fix error of goreleaser on travis ci when pushed new tag.

```
Deploying application
   • releasing using goreleaser 0.101.0...
   • loading config file       file=.goreleaser.yml
   • RUNNING BEFORE HOOKS
      • running go mod download
   • GETTING AND VALIDATING GIT STATE
      • releasing v0.8.1, commit 0e8cdf3f93f52c044db367dbed91a6dc204b93be
   ⨯ release failed after 0.06s error=git is currently in a dirty state:
 M README.md
 M go.mod
 M go.sum
```